### PR TITLE
NodeJS 4.x migrate from sys to util

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,14 +72,14 @@ Usage Notes
 *Example client*
 
     var pb = require('webos-sysbus');
-    var sys = require('sys');
+    var util = require('util');
     var _ = require('underscore')._;
 
     function responseArrived(message) {
-    	sys.log("responseArrived[" + message.responseToken() + "]:" + message.payload());
+    	uril.log("responseArrived[" + message.responseToken() + "]:" + message.payload());
     }
 
-    sys.log("creating ls2 handle object");
+    util.log("creating ls2 handle object");
 
     var h = new pb.Handle("com.sample.service", false);
 

--- a/README.md
+++ b/README.md
@@ -72,14 +72,13 @@ Usage Notes
 *Example client*
 
     var pb = require('webos-sysbus');
-    var util = require('util');
     var _ = require('underscore')._;
 
     function responseArrived(message) {
     	uril.log("responseArrived[" + message.responseToken() + "]:" + message.payload());
     }
 
-    util.log("creating ls2 handle object");
+    console.log("creating ls2 handle object");
 
     var h = new pb.Handle("com.sample.service", false);
 

--- a/src/test/js_service_node.js
+++ b/src/test/js_service_node.js
@@ -18,21 +18,21 @@
 
 //var pb = require('webos-sysbus');
 var pb = require('palmbus');
-var sys = require('sys');
+var util = require('util');
 var _ = require('underscore')._;
 
 var h;
 
-sys.log("creating javascript service");
+util.log("creating javascript service");
 
 function testCallback (message) {
-    sys.log("payload in testCallback: '" + message.payload() + "'");
+    util.log("payload in testCallback: '" + message.payload() + "'");
     var r = {msg: "ahoy, matie " + message.payload()};
     message.respond(JSON.stringify(r));
 }
 
 function delayCallback (message) {
-    sys.log("payload in testCallback: '" + message.payload() + "'");
+    util.log("payload in testCallback: '" + message.payload() + "'");
     var params = JSON.parse(message.payload());
     var r = {
         msg: "ahoy, matie ",
@@ -59,7 +59,7 @@ function dieCallback (message) {
 }
 
 function requestArrived(message) {
-    sys.log("requestArrived");
+    util.log("requestArrived");
     message.print();
     switch(message.method()) {
     case "test":

--- a/src/test/js_service_node.js
+++ b/src/test/js_service_node.js
@@ -18,21 +18,20 @@
 
 //var pb = require('webos-sysbus');
 var pb = require('palmbus');
-var util = require('util');
 var _ = require('underscore')._;
 
 var h;
 
-util.log("creating javascript service");
+console.log("creating javascript service");
 
 function testCallback (message) {
-    util.log("payload in testCallback: '" + message.payload() + "'");
+    console.log("payload in testCallback: '" + message.payload() + "'");
     var r = {msg: "ahoy, matie " + message.payload()};
     message.respond(JSON.stringify(r));
 }
 
 function delayCallback (message) {
-    util.log("payload in testCallback: '" + message.payload() + "'");
+    console.log("payload in testCallback: '" + message.payload() + "'");
     var params = JSON.parse(message.payload());
     var r = {
         msg: "ahoy, matie ",
@@ -59,7 +58,7 @@ function dieCallback (message) {
 }
 
 function requestArrived(message) {
-    util.log("requestArrived");
+    console.log("requestArrived");
     message.print();
     switch(message.method()) {
     case "test":

--- a/src/test/ls2_test.js
+++ b/src/test/ls2_test.js
@@ -18,21 +18,20 @@
 
 //var pb = require('webos-sysbus');
 var pb = require('palmbus');
-var util = require('util');
 var _ = require('underscore')._;
 
-util.log("creating javascript service client");
+console.log("creating javascript service client");
 
 function responseArrived(message) {
-	util.log("responseArrived[" + message.responseToken() + "]:" + message.payload());
+	console.log("responseArrived[" + message.responseToken() + "]:" + message.payload());
 }
 
 function delayWithTimeoutResponseArrived(message) {
-	util.log("delayWithTimeoutResponseArrived[" + message.responseToken() + "]:" + message.payload());
+	console.log("delayWithTimeoutResponseArrived[" + message.responseToken() + "]:" + message.payload());
 }
 
 function delayResponseArrived(message) {
-	util.log("delayResponseArrived[" + message.responseToken() + "]:" + message.payload());
+	console.log("delayResponseArrived[" + message.responseToken() + "]:" + message.payload());
 }
 
 var h = new pb.Handle("com.sample.service", false);

--- a/src/test/ls2_test.js
+++ b/src/test/ls2_test.js
@@ -18,21 +18,21 @@
 
 //var pb = require('webos-sysbus');
 var pb = require('palmbus');
-var sys = require('sys');
+var util = require('util');
 var _ = require('underscore')._;
 
-sys.log("creating javascript service client");
+util.log("creating javascript service client");
 
 function responseArrived(message) {
-	sys.log("responseArrived[" + message.responseToken() + "]:" + message.payload());
+	util.log("responseArrived[" + message.responseToken() + "]:" + message.payload());
 }
 
 function delayWithTimeoutResponseArrived(message) {
-	sys.log("delayWithTimeoutResponseArrived[" + message.responseToken() + "]:" + message.payload());
+	util.log("delayWithTimeoutResponseArrived[" + message.responseToken() + "]:" + message.payload());
 }
 
 function delayResponseArrived(message) {
-	sys.log("delayResponseArrived[" + message.responseToken() + "]:" + message.payload());
+	util.log("delayResponseArrived[" + message.responseToken() + "]:" + message.payload());
 }
 
 var h = new pb.Handle("com.sample.service", false);


### PR DESCRIPTION
sys.log has been deprecated and util.log should be used instead.

Signed-off-by: Herman van Hazendonk github.com@herrie.org
