### PR TITLE
nodejs-modules-sysbus: Add permissions for various services

### DIFF
--- a/files/sysbus/com.palm.nodejs.json.prv.in
+++ b/files/sysbus/com.palm.nodejs.json.prv.in
@@ -1,8 +1,48 @@
 {
     "role": {
-        "exeName":"@WEBOS_INSTALL_BINDIR@/node",
+        "exeName": "@WEBOS_INSTALL_BINDIR@/node",
         "type": "privileged",
         "allowedNames": ["*"]
     },
-    "permissions": []
+    "permissions": [{
+            "service": "com.palm.keymanager",
+            "inbound": ["*"],
+            "outbound": ["*"]
+        },
+        {
+            "service": "com.palm.service.accounts",
+            "inbound": ["*"],
+            "outbound": ["*"]
+        },
+        {
+            "service": "com.palm.service.calendar.reminders",
+            "inbound": ["*"],
+            "outbound": ["*"]
+        },
+        {
+            "service": "com.palm.service.contacts",
+            "inbound": ["*"],
+            "outbound": ["*"]
+        },
+        {
+            "service": "com.palm.service.contacts.linker",
+            "inbound": ["*"],
+            "outbound": ["*"]
+        },
+        {
+            "service": "org.webosinternals.tweaks.prefs",
+            "inbound": ["*"],
+            "outbound": ["*"]
+        },
+        {
+            "service": "org.webosports.service.update",
+            "inbound": ["*"],
+            "outbound": ["*"]
+        },
+        {
+            "service": "",
+            "inbound": ["*"],
+            "outbound": ["*"]
+        }
+    ]
 }

--- a/files/sysbus/com.palm.nodejs.json.pub.in
+++ b/files/sysbus/com.palm.nodejs.json.pub.in
@@ -1,8 +1,48 @@
 {
     "role": {
-        "exeName":"@WEBOS_INSTALL_BINDIR@/node",
+        "exeName": "@WEBOS_INSTALL_BINDIR@/node",
         "type": "privileged",
         "allowedNames": ["*"]
     },
-    "permissions": []
+    "permissions": [{
+            "service": "com.palm.keymanager",
+            "inbound": ["*"],
+            "outbound": ["*"]
+        },
+        {
+            "service": "com.palm.service.accounts",
+            "inbound": ["*"],
+            "outbound": ["*"]
+        },
+        {
+            "service": "com.palm.service.calendar.reminders",
+            "inbound": ["*"],
+            "outbound": ["*"]
+        },
+        {
+            "service": "com.palm.service.contacts",
+            "inbound": ["*"],
+            "outbound": ["*"]
+        },
+        {
+            "service": "com.palm.service.contacts.linker",
+            "inbound": ["*"],
+            "outbound": ["*"]
+        },
+        {
+            "service": "org.webosinternals.tweaks.prefs",
+            "inbound": ["*"],
+            "outbound": ["*"]
+        },
+        {
+            "service": "org.webosports.service.update",
+            "inbound": ["*"],
+            "outbound": ["*"]
+        },
+        {
+            "service": "",
+            "inbound": ["*"],
+            "outbound": ["*"]
+        }
+    ]
 }


### PR DESCRIPTION
Solves errors like:

Can not find service "org.webosports.service.update" permissions for executable "/usr/bin/node"

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>